### PR TITLE
Add initial .NET solution scaffold and refine Spec.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+bin/
+obj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+.vs/

--- a/Near.sln
+++ b/Near.sln
@@ -1,0 +1,45 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Near.App", "src\Near.App\Near.App.csproj", "{D81CAD84-F808-4BC6-8F2E-D199F1006599}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Near.Core", "src\Near.Core\Near.Core.csproj", "{B173D372-6248-4260-BBC6-2E340D60EB13}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Near.Services", "src\Near.Services\Near.Services.csproj", "{41724434-BF63-4082-8584-DDF5BDEAFE94}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Near.Infrastructure", "src\Near.Infrastructure\Near.Infrastructure.csproj", "{420E7BCA-4F85-4317-87DB-09DD6F59286B}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Near.UI", "src\Near.UI\Near.UI.csproj", "{B4DF2242-6C60-4C9C-8BCC-03B0D2B2CE00}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D81CAD84-F808-4BC6-8F2E-D199F1006599}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D81CAD84-F808-4BC6-8F2E-D199F1006599}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D81CAD84-F808-4BC6-8F2E-D199F1006599}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D81CAD84-F808-4BC6-8F2E-D199F1006599}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B173D372-6248-4260-BBC6-2E340D60EB13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B173D372-6248-4260-BBC6-2E340D60EB13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B173D372-6248-4260-BBC6-2E340D60EB13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B173D372-6248-4260-BBC6-2E340D60EB13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{41724434-BF63-4082-8584-DDF5BDEAFE94}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{41724434-BF63-4082-8584-DDF5BDEAFE94}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{41724434-BF63-4082-8584-DDF5BDEAFE94}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{41724434-BF63-4082-8584-DDF5BDEAFE94}.Release|Any CPU.Build.0 = Release|Any CPU
+		{420E7BCA-4F85-4317-87DB-09DD6F59286B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{420E7BCA-4F85-4317-87DB-09DD6F59286B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{420E7BCA-4F85-4317-87DB-09DD6F59286B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{420E7BCA-4F85-4317-87DB-09DD6F59286B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B4DF2242-6C60-4C9C-8BCC-03B0D2B2CE00}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B4DF2242-6C60-4C9C-8BCC-03B0D2B2CE00}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B4DF2242-6C60-4C9C-8BCC-03B0D2B2CE00}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B4DF2242-6C60-4C9C-8BCC-03B0D2B2CE00}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Spec.md
+++ b/Spec.md
@@ -38,6 +38,38 @@ The app runs entirely in a terminal window and uses **Terminal.Gui (v2)** for a 
 * **Customizable**: configurable layout, panels, key bindings, and key chords.
 * **Cross-platform**: Windows + Linux + macOS (with platform-specific terminal backends where needed).
 
+### 2.3 Repository + solution structure (initial scaffolding)
+
+The repository starts with a minimal, layered solution layout so future implementation work can drop into predictable modules.
+
+* **Root**
+  * `Near.sln` for solution-wide builds.
+  * `Spec.md` (this document).
+  * `.gitignore` for build outputs and IDE artifacts.
+* **src/Near.App**
+  * Console entry point and composition root.
+  * Responsible for wiring DI, configuration, and bootstrapping the UI host.
+* **src/Near.Core**
+  * Domain models, commands, state types, and pure logic with no UI dependencies.
+* **src/Near.Services**
+  * Application services and orchestration (background tasks, coordination between core + infrastructure).
+* **src/Near.Infrastructure**
+  * External integrations (filesystem, git CLI, terminal backends, config persistence).
+* **src/Near.UI**
+  * Terminal.Gui views, panels, layout, and input routing.
+
+> Note: This scaffolding is intentionally light. We are **not** implementing features yet; only setting up structure.
+
+### 2.4 Local build + run (placeholder)
+
+These commands will become usable once the implementation arrives and the .NET SDK is installed.
+
+* Build: `dotnet build Near.sln`
+* Run: `dotnet run --project src/Near.App`
+* Tests (when added): `dotnet test`
+
+Terminal.Gui apps generally require a real terminal (not a redirected/embedded console).
+
 ---
 
 ## 3. Guiding Principles
@@ -127,6 +159,15 @@ The app runs entirely in a terminal window and uses **Terminal.Gui (v2)** for a 
 * When panels are hidden: terminal expands to fill available space (“panels off”)
 * Option to synchronize terminal working directory with active file panel (off by default)
 * Command to send paths/selections to terminal (paste path, `cd`, etc.)
+
+### 4.5 Explicit non-goals for the initial scaffold
+
+To keep this phase focused on structure and documentation, the following are **not** part of the initial scaffold: 
+
+* Functional file operations, git commands, or terminal emulation.
+* UI rendering beyond placeholder startup.
+* Persistence of settings, bookmarks, or layout.
+* Tests and benchmarks (they will be introduced once concrete implementations exist).
 
 ---
 
@@ -296,22 +337,32 @@ We use a clean architecture style:
    * input routing → command dispatcher
    * rendering and layout
 
-### 7.2 Project structure (suggested)
+### 7.2 Project structure (scaffolded)
 
-* `App/` (entry point, host, composition root)
-* `Core/`
+The solution is structured as multiple SDK-style projects under `src/` to keep dependencies directional and clear.
 
-  * `Models/`, `Commands/`, `State/`, `Utilities/`
-* `Services/`
+* `src/Near.App/` (entry point, host, composition root)
+* `src/Near.Core/`
 
-  * `FileOperations/`, `Git/`, `Search/`, `Tasks/`
-* `Infrastructure/`
+  * `Models/`, `Commands/`, `State/`, `Utilities/` (domain + pure logic)
+* `src/Near.Services/`
 
-  * `FileSystem/`, `GitCli/`, `Terminal/`, `Config/`, `Logging/`
-* `UI/`
+  * `FileOperations/`, `Git/`, `Search/`, `Tasks/` (application orchestration)
+* `src/Near.Infrastructure/`
 
-  * `Panels/`, `Layout/`, `Input/`, `Views/`, `Theming/`
-* `Plugins/` (optional later)
+  * `FileSystem/`, `GitCli/`, `Terminal/`, `Config/`, `Logging/` (external adapters)
+* `src/Near.UI/`
+
+  * `Panels/`, `Layout/`, `Input/`, `Views/`, `Theming/` (Terminal.Gui-based UI)
+* `src/Plugins/` (optional later)
+
+Dependency intent (high level):
+
+* **Near.Core** has no dependencies on other projects.
+* **Near.Services** depends on Core.
+* **Near.Infrastructure** depends on Core.
+* **Near.UI** depends on Core + Services.
+* **Near.App** depends on all other projects and wires them together.
 
 ### 7.3 Dependency injection and hosting
 

--- a/src/Near.App/Near.App.csproj
+++ b/src/Near.App/Near.App.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
+    <ProjectReference Include="..\Near.Services\Near.Services.csproj" />
+    <ProjectReference Include="..\Near.Infrastructure\Near.Infrastructure.csproj" />
+    <ProjectReference Include="..\Near.UI\Near.UI.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Near.App/Program.cs
+++ b/src/Near.App/Program.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Near.App;
+
+internal static class Program
+{
+    public static void Main(string[] args)
+    {
+        Console.WriteLine("Near app bootstrap placeholder.");
+    }
+}

--- a/src/Near.Core/Near.Core.csproj
+++ b/src/Near.Core/Near.Core.csproj
@@ -1,0 +1,7 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/src/Near.Infrastructure/Near.Infrastructure.csproj
+++ b/src/Near.Infrastructure/Near.Infrastructure.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Near.Services/Near.Services.csproj
+++ b/src/Near.Services/Near.Services.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Near.UI/Near.UI.csproj
+++ b/src/Near.UI/Near.UI.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
+    <ProjectReference Include="..\Near.Services\Near.Services.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
### Motivation

- Establish a minimal, directional repo layout so later implementation work has a predictable multi-project structure.
- Provide a lightweight app entrypoint and SDK-style projects for `Near.App`, `Near.Core`, `Near.Services`, `Near.Infrastructure`, and `Near.UI` to wire future work into.
- Record and refine design guidance in `Spec.md` to align project structure, build/run notes, and explicit non-goals for the scaffold phase.
- Add basic housekeeping for development (`.gitignore`) so generated build artifacts and IDE files are excluded.

### Description

- Added solution file `Near.sln` and created SDK-style projects under `src/` with `*.csproj` files and cross-project references (e.g., `Near.App` references Core/Services/Infrastructure/UI). 
- Added a minimal app entry point `src/Near.App/Program.cs` that prints a bootstrap placeholder and can be replaced by the host/bootstrapping logic later. 
- Expanded and polished `Spec.md` to include the concrete repository/solution layout, placeholder local build/run commands (`dotnet build`, `dotnet run`), and a short list of explicit non-goals for the initial scaffold. 
- Added root `.gitignore` to ignore `bin/`, `obj/`, IDE artifacts, and created the initial commit capturing these changes.

### Testing

- No automated tests were executed as part of this change because the .NET SDK is not available in the rollout environment and build/test commands were not runnable.
- No `dotnet build`/`dotnet test` was run; the commit contains only project scaffolding and documentation updates intended for follow-up implementation and CI validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960405af2a0832eadf3cb7765aef633)