### PR TITLE
Initial scaffold per Spec.md: core models, services, DI and Terminal.Gui host

### DIFF
--- a/src/Near.App/Near.App.csproj
+++ b/src/Near.App/Near.App.csproj
@@ -12,4 +12,8 @@
     <ProjectReference Include="..\Near.Infrastructure\Near.Infrastructure.csproj" />
     <ProjectReference Include="..\Near.UI\Near.UI.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Near.App/Program.cs
+++ b/src/Near.App/Program.cs
@@ -1,11 +1,33 @@
 using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Near.Infrastructure;
+using Near.Services;
+using Near.UI;
 
 namespace Near.App;
 
 internal static class Program
 {
-    public static void Main(string[] args)
+    public static async Task Main(string[] args)
     {
-        Console.WriteLine("Near app bootstrap placeholder.");
+        var initialDirectory = Environment.CurrentDirectory;
+
+        using var host = Host.CreateDefaultBuilder(args)
+            .ConfigureServices(services =>
+            {
+                services.AddNearServices(initialDirectory);
+                services.AddNearInfrastructure();
+                services.AddNearUi();
+            })
+            .Build();
+
+        await host.StartAsync();
+
+        var appHost = host.Services.GetRequiredService<IAppHost>();
+        await appHost.RunAsync(default);
+
+        await host.StopAsync();
     }
 }

--- a/src/Near.Core/Commands/CommandContext.cs
+++ b/src/Near.Core/Commands/CommandContext.cs
@@ -1,0 +1,5 @@
+using System;
+
+namespace Near.Core.Commands;
+
+public sealed record CommandContext(IServiceProvider Services);

--- a/src/Near.Core/Commands/CommandDefinition.cs
+++ b/src/Near.Core/Commands/CommandDefinition.cs
@@ -1,0 +1,22 @@
+using System.Collections.Generic;
+
+namespace Near.Core.Commands;
+
+public sealed record CommandDefinition(
+    string Id,
+    string Title,
+    string Description,
+    IReadOnlyList<KeyBinding> DefaultBindings,
+    CommandContextType Context
+);
+
+public enum CommandContextType
+{
+    Any,
+    Global,
+    FilePanel,
+    GitPanel,
+    Terminal
+}
+
+public sealed record KeyBinding(string Gesture);

--- a/src/Near.Core/Commands/ICommand.cs
+++ b/src/Near.Core/Commands/ICommand.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Near.Core.Commands;
+
+public interface ICommand
+{
+    Task ExecuteAsync(CommandContext context, CancellationToken cancellationToken);
+}

--- a/src/Near.Core/Models/CommitEntry.cs
+++ b/src/Near.Core/Models/CommitEntry.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Collections.Generic;
+
+namespace Near.Core.Models;
+
+public sealed record CommitEntry(
+    string Hash,
+    IReadOnlyList<string> Parents,
+    string AuthorName,
+    DateTimeOffset AuthorDate,
+    string Subject,
+    IReadOnlyList<string> Decorations
+);

--- a/src/Near.Core/Models/DiffDocument.cs
+++ b/src/Near.Core/Models/DiffDocument.cs
@@ -1,0 +1,32 @@
+using System.Collections.Generic;
+
+namespace Near.Core.Models;
+
+public sealed record DiffDocument(IReadOnlyList<DiffFile> Files);
+
+public sealed record DiffFile(
+    string OldPath,
+    string NewPath,
+    IReadOnlyList<DiffHunk> Hunks,
+    DiffStats? Stats
+);
+
+public sealed record DiffStats(int Added, int Deleted);
+
+public sealed record DiffHunk(
+    int OldStart,
+    int OldCount,
+    int NewStart,
+    int NewCount,
+    IReadOnlyList<DiffLine> Lines
+);
+
+public enum DiffLineKind
+{
+    Context,
+    Add,
+    Remove,
+    Meta
+}
+
+public sealed record DiffLine(DiffLineKind Kind, string Text);

--- a/src/Near.Core/Models/RefEntry.cs
+++ b/src/Near.Core/Models/RefEntry.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace Near.Core.Models;
+
+public sealed record RefEntry(
+    string Name,
+    string FullName,
+    string TargetHash,
+    DateTimeOffset? Date,
+    string? Upstream,
+    int? Ahead,
+    int? Behind
+);
+
+public sealed record StashEntry(
+    string Name,
+    DateTimeOffset Date,
+    string Message
+);

--- a/src/Near.Core/Models/RepoContext.cs
+++ b/src/Near.Core/Models/RepoContext.cs
@@ -1,0 +1,33 @@
+using System;
+
+namespace Near.Core.Models;
+
+public sealed record RepoContext(
+    string RepoRoot,
+    string GitDir,
+    bool IsBare,
+    HeadInfo Head,
+    UpstreamInfo? Upstream,
+    DirtySummary DirtySummary,
+    DateTimeOffset LastRefreshedAt
+);
+
+public sealed record HeadInfo(
+    string HeadRefName,
+    string HeadCommitHash,
+    bool IsDetached
+);
+
+public sealed record UpstreamInfo(
+    string UpstreamRefName,
+    int Ahead,
+    int Behind
+);
+
+public sealed record DirtySummary(
+    int Conflicts,
+    int Unstaged,
+    int Staged,
+    int Untracked,
+    int Ignored
+);

--- a/src/Near.Core/Models/StatusEntry.cs
+++ b/src/Near.Core/Models/StatusEntry.cs
@@ -1,0 +1,18 @@
+namespace Near.Core.Models;
+
+public enum StatusGroup
+{
+    Conflicts,
+    Unstaged,
+    Staged,
+    Untracked,
+    Ignored
+}
+
+public sealed record StatusEntry(
+    StatusGroup Group,
+    string Path,
+    string? SecondaryPath,
+    string Code,
+    bool IsSubmodule
+);

--- a/src/Near.Core/State/AppState.cs
+++ b/src/Near.Core/State/AppState.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Collections.Generic;
+using Near.Core.Models;
+
+namespace Near.Core.State;
+
+public sealed record PanelState(
+    string Id,
+    string CurrentDirectory,
+    string? SelectedItem
+);
+
+public sealed record BackgroundTaskInfo(
+    Guid Id,
+    string Title,
+    string? Message,
+    double? Progress
+);
+
+public sealed record AppState(
+    string ActivePanelId,
+    PanelState LeftPanel,
+    PanelState RightPanel,
+    bool PanelsVisible,
+    int TerminalHeight,
+    RepoContext? ActiveRepo,
+    IReadOnlyList<BackgroundTaskInfo> RunningTasks
+)
+{
+    public static AppState CreateDefault(string initialDirectory)
+    {
+        var left = new PanelState("left", initialDirectory, null);
+        var right = new PanelState("right", initialDirectory, null);
+
+        return new AppState(
+            ActivePanelId: left.Id,
+            LeftPanel: left,
+            RightPanel: right,
+            PanelsVisible: true,
+            TerminalHeight: 7,
+            ActiveRepo: null,
+            RunningTasks: Array.Empty<BackgroundTaskInfo>()
+        );
+    }
+
+    public static AppState Reduce(AppState state, IAction action)
+    {
+        return state;
+    }
+}

--- a/src/Near.Core/State/IAction.cs
+++ b/src/Near.Core/State/IAction.cs
@@ -1,0 +1,5 @@
+namespace Near.Core.State;
+
+public interface IAction
+{
+}

--- a/src/Near.Core/State/IStateStore.cs
+++ b/src/Near.Core/State/IStateStore.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Near.Core.State;
+
+public interface IStateStore<T>
+{
+    T Current { get; }
+
+    IDisposable Subscribe(Action<T> observer);
+
+    void Dispatch(IAction action);
+}

--- a/src/Near.Infrastructure/GitCli/GitProcessRunner.cs
+++ b/src/Near.Infrastructure/GitCli/GitProcessRunner.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Diagnostics;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Near.Services.Git;
+
+namespace Near.Infrastructure.GitCli;
+
+public sealed class GitProcessRunner : IGitProcessRunner
+{
+    private readonly string _gitPath;
+
+    public GitProcessRunner(string gitPath = "git")
+    {
+        _gitPath = gitPath;
+    }
+
+    public async Task<GitProcessResult> RunAsync(GitProcessRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            throw new ArgumentNullException(nameof(request));
+        }
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = _gitPath,
+            Arguments = request.Arguments,
+            WorkingDirectory = request.WorkingDirectory,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+
+        var output = new StringBuilder();
+        var error = new StringBuilder();
+
+        using var process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+
+        process.OutputDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                output.AppendLine(args.Data);
+            }
+        };
+
+        process.ErrorDataReceived += (_, args) =>
+        {
+            if (args.Data is not null)
+            {
+                error.AppendLine(args.Data);
+            }
+        };
+
+        if (!process.Start())
+        {
+            throw new InvalidOperationException("Failed to start git process.");
+        }
+
+        process.BeginOutputReadLine();
+        process.BeginErrorReadLine();
+
+        await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+
+        return new GitProcessResult(process.ExitCode, output.ToString(), error.ToString());
+    }
+}

--- a/src/Near.Infrastructure/Near.Infrastructure.csproj
+++ b/src/Near.Infrastructure/Near.Infrastructure.csproj
@@ -8,4 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Near.Infrastructure/ServiceCollectionExtensions.cs
+++ b/src/Near.Infrastructure/ServiceCollectionExtensions.cs
@@ -1,0 +1,15 @@
+using Microsoft.Extensions.DependencyInjection;
+using Near.Infrastructure.GitCli;
+using Near.Services.Git;
+
+namespace Near.Infrastructure;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNearInfrastructure(this IServiceCollection services)
+    {
+        services.AddSingleton<IGitProcessRunner, GitProcessRunner>();
+
+        return services;
+    }
+}

--- a/src/Near.Services/Events/EventBus.cs
+++ b/src/Near.Services/Events/EventBus.cs
@@ -1,0 +1,28 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+
+namespace Near.Services.Events;
+
+public interface IEventBus<T>
+{
+    ValueTask PublishAsync(T item, CancellationToken cancellationToken = default);
+
+    IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default);
+}
+
+public sealed class EventBus<T> : IEventBus<T>
+{
+    private readonly Channel<T> _channel = Channel.CreateUnbounded<T>();
+
+    public ValueTask PublishAsync(T item, CancellationToken cancellationToken = default)
+    {
+        return _channel.Writer.WriteAsync(item, cancellationToken);
+    }
+
+    public IAsyncEnumerable<T> ReadAllAsync(CancellationToken cancellationToken = default)
+    {
+        return _channel.Reader.ReadAllAsync(cancellationToken);
+    }
+}

--- a/src/Near.Services/Git/GitContracts.cs
+++ b/src/Near.Services/Git/GitContracts.cs
@@ -1,0 +1,64 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Near.Core.Models;
+
+namespace Near.Services.Git;
+
+public sealed record DiffRequest(
+    string RepoRoot,
+    string? Path,
+    DiffTarget Target
+);
+
+public enum DiffTarget
+{
+    WorkingTreeVsHead,
+    IndexVsHead,
+    Commit,
+    Stash
+}
+
+public sealed record LogRequest(
+    string RepoRoot,
+    string? Ref,
+    int Skip,
+    int Take,
+    string? Path
+);
+
+public sealed record GitProcessRequest(
+    string Arguments,
+    string WorkingDirectory
+);
+
+public sealed record GitProcessResult(
+    int ExitCode,
+    string StandardOutput,
+    string StandardError
+);
+
+public interface IGitRepoLocator
+{
+    Task<RepoContext?> LocateAsync(string path, CancellationToken cancellationToken);
+}
+
+public interface IGitQueryService
+{
+    Task<RepoContext> GetRepoContextAsync(string repoRoot, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<StatusEntry>> GetStatusAsync(string repoRoot, CancellationToken cancellationToken);
+
+    Task<DiffDocument> GetDiffAsync(DiffRequest request, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<CommitEntry>> GetLogPageAsync(LogRequest request, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<RefEntry>> GetRefsAsync(string repoRoot, CancellationToken cancellationToken);
+
+    Task<IReadOnlyList<StashEntry>> GetStashesAsync(string repoRoot, CancellationToken cancellationToken);
+}
+
+public interface IGitProcessRunner
+{
+    Task<GitProcessResult> RunAsync(GitProcessRequest request, CancellationToken cancellationToken);
+}

--- a/src/Near.Services/Near.Services.csproj
+++ b/src/Near.Services/Near.Services.csproj
@@ -8,4 +8,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+  </ItemGroup>
 </Project>

--- a/src/Near.Services/ServiceCollectionExtensions.cs
+++ b/src/Near.Services/ServiceCollectionExtensions.cs
@@ -1,0 +1,18 @@
+using Microsoft.Extensions.DependencyInjection;
+using Near.Core.State;
+using Near.Services.State;
+using Near.Services.Tasks;
+
+namespace Near.Services;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNearServices(this IServiceCollection services, string initialDirectory)
+    {
+        services.AddSingleton<IStateStore<AppState>>(_ =>
+            new StateStore<AppState>(AppState.CreateDefault(initialDirectory), AppState.Reduce));
+        services.AddSingleton<ITaskRunner>(_ => new TaskRunner());
+
+        return services;
+    }
+}

--- a/src/Near.Services/State/StateStore.cs
+++ b/src/Near.Services/State/StateStore.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Collections.Generic;
+using Near.Core.State;
+
+namespace Near.Services.State;
+
+public sealed class StateStore<T> : IStateStore<T>
+{
+    private readonly object _lock = new();
+    private readonly List<Action<T>> _observers = new();
+    private readonly Func<T, IAction, T> _reducer;
+
+    public StateStore(T initialState, Func<T, IAction, T> reducer)
+    {
+        Current = initialState;
+        _reducer = reducer;
+    }
+
+    public T Current { get; private set; }
+
+    public IDisposable Subscribe(Action<T> observer)
+    {
+        if (observer is null)
+        {
+            throw new ArgumentNullException(nameof(observer));
+        }
+
+        lock (_lock)
+        {
+            _observers.Add(observer);
+        }
+
+        observer(Current);
+
+        return new Subscription(() => Unsubscribe(observer));
+    }
+
+    public void Dispatch(IAction action)
+    {
+        if (action is null)
+        {
+            throw new ArgumentNullException(nameof(action));
+        }
+
+        List<Action<T>> observersSnapshot;
+
+        lock (_lock)
+        {
+            Current = _reducer(Current, action);
+            observersSnapshot = new List<Action<T>>(_observers);
+        }
+
+        foreach (var observer in observersSnapshot)
+        {
+            observer(Current);
+        }
+    }
+
+    private void Unsubscribe(Action<T> observer)
+    {
+        lock (_lock)
+        {
+            _observers.Remove(observer);
+        }
+    }
+
+    private sealed class Subscription : IDisposable
+    {
+        private readonly Action _dispose;
+        private bool _isDisposed;
+
+        public Subscription(Action dispose)
+        {
+            _dispose = dispose;
+        }
+
+        public void Dispose()
+        {
+            if (_isDisposed)
+            {
+                return;
+            }
+
+            _dispose();
+            _isDisposed = true;
+        }
+    }
+}

--- a/src/Near.Services/Tasks/TaskRunner.cs
+++ b/src/Near.Services/Tasks/TaskRunner.cs
@@ -1,0 +1,63 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Near.Services.Tasks;
+
+public sealed record ProgressInfo(double? Percent, string Message);
+
+public interface IBackgroundTask
+{
+    Guid Id { get; }
+
+    string Title { get; }
+
+    Task RunAsync(IProgress<ProgressInfo> progress, CancellationToken cancellationToken);
+}
+
+public sealed record TaskHandle(Guid Id, Task Task);
+
+public interface ITaskRunner
+{
+    TaskHandle Enqueue(IBackgroundTask task, CancellationToken cancellationToken = default);
+}
+
+public sealed class TaskRunner : ITaskRunner
+{
+    private readonly SemaphoreSlim _semaphore;
+
+    public TaskRunner(int maxConcurrency = 2)
+    {
+        if (maxConcurrency < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(maxConcurrency));
+        }
+
+        _semaphore = new SemaphoreSlim(maxConcurrency, maxConcurrency);
+    }
+
+    public TaskHandle Enqueue(IBackgroundTask task, CancellationToken cancellationToken = default)
+    {
+        if (task is null)
+        {
+            throw new ArgumentNullException(nameof(task));
+        }
+
+        var runTask = RunTaskAsync(task, cancellationToken);
+        return new TaskHandle(task.Id, runTask);
+    }
+
+    private async Task RunTaskAsync(IBackgroundTask task, CancellationToken cancellationToken)
+    {
+        await _semaphore.WaitAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            var progress = new Progress<ProgressInfo>();
+            await task.RunAsync(progress, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            _semaphore.Release();
+        }
+    }
+}

--- a/src/Near.UI/IAppHost.cs
+++ b/src/Near.UI/IAppHost.cs
@@ -1,0 +1,9 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Near.UI;
+
+public interface IAppHost
+{
+    Task RunAsync(CancellationToken cancellationToken);
+}

--- a/src/Near.UI/Layout/MainLayoutView.cs
+++ b/src/Near.UI/Layout/MainLayoutView.cs
@@ -1,0 +1,83 @@
+using Terminal.Gui;
+
+namespace Near.UI.Layout;
+
+public sealed class MainLayoutView : View
+{
+    private const int TopBarHeight = 1;
+    private const int TerminalHeight = 7;
+    private const int FooterHeight = 1;
+
+    public MainLayoutView()
+    {
+        Width = Dim.Fill();
+        Height = Dim.Fill();
+
+        var topBar = new View
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = TopBarHeight
+        };
+        topBar.Add(new Label("Near - File & Git Manager")
+        {
+            X = 0,
+            Y = 0
+        });
+
+        var workspace = new View
+        {
+            X = 0,
+            Y = TopBarHeight,
+            Width = Dim.Fill(),
+            Height = Dim.Fill(TerminalHeight + FooterHeight)
+        };
+
+        var leftPanel = new FrameView("Left Panel")
+        {
+            X = 0,
+            Y = 0,
+            Width = Dim.Percent(50),
+            Height = Dim.Fill()
+        };
+
+        var rightPanel = new FrameView("Right Panel")
+        {
+            X = Pos.Right(leftPanel),
+            Y = 0,
+            Width = Dim.Fill(),
+            Height = Dim.Fill()
+        };
+
+        workspace.Add(leftPanel, rightPanel);
+
+        var terminal = new FrameView("Terminal (pwsh)")
+        {
+            X = 0,
+            Y = Pos.AnchorEnd(TerminalHeight + FooterHeight),
+            Width = Dim.Fill(),
+            Height = TerminalHeight
+        };
+        terminal.Add(new Label("Terminal session placeholder")
+        {
+            X = 1,
+            Y = 0
+        });
+
+        var footer = new View
+        {
+            X = 0,
+            Y = Pos.AnchorEnd(FooterHeight),
+            Width = Dim.Fill(),
+            Height = FooterHeight
+        };
+        footer.Add(new Label("F1 Help | Ctrl+O Toggle Panels | F10 Exit")
+        {
+            X = 0,
+            Y = 0
+        });
+
+        Add(topBar, workspace, terminal, footer);
+    }
+}

--- a/src/Near.UI/Near.UI.csproj
+++ b/src/Near.UI/Near.UI.csproj
@@ -9,4 +9,9 @@
     <ProjectReference Include="..\Near.Core\Near.Core.csproj" />
     <ProjectReference Include="..\Near.Services\Near.Services.csproj" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="Terminal.Gui" Version="2.4.0" />
+  </ItemGroup>
 </Project>

--- a/src/Near.UI/ServiceCollectionExtensions.cs
+++ b/src/Near.UI/ServiceCollectionExtensions.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Near.UI;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddNearUi(this IServiceCollection services)
+    {
+        services.AddSingleton<IAppHost, TerminalGuiAppHost>();
+
+        return services;
+    }
+}

--- a/src/Near.UI/TerminalGuiAppHost.cs
+++ b/src/Near.UI/TerminalGuiAppHost.cs
@@ -1,0 +1,23 @@
+using System.Threading;
+using System.Threading.Tasks;
+using Terminal.Gui;
+using Near.UI.Layout;
+
+namespace Near.UI;
+
+public sealed class TerminalGuiAppHost : IAppHost
+{
+    public Task RunAsync(CancellationToken cancellationToken)
+    {
+        Application.Init();
+
+        var top = Application.Top;
+        top.Add(new MainLayoutView());
+
+        using var registration = cancellationToken.Register(Application.RequestStop);
+        Application.Run();
+        Application.Shutdown();
+
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
### Motivation

- Implement the project scaffold described in `Spec.md` to provide a predictable foundation for future features.  
- Introduce core domain models, command and state abstractions so higher-level services and UI can be implemented against stable types.  
- Wire a minimal host + UI placeholder to enable iterative development and manual verification of application startup.

### Description

- Add core command and domain model types (commands, `RepoContext`, `CommitEntry`, `DiffDocument`, `RefEntry`, `StatusEntry`) and application state (`AppState`, `IStateStore`, `IAction`).  
- Implement service primitives including `StateStore`, an `EventBus`, `TaskRunner` (background task abstraction), git contracts (`IGitQueryService`, `IGitProcessRunner`, etc.), and a `GitProcessRunner` CLI-backed implementation.  
- Add Terminal.Gui placeholder UI components (`MainLayoutView`, `TerminalGuiAppHost`), DI registration extensions (`AddNearServices`, `AddNearInfrastructure`, `AddNearUi`), and update `Program.cs` to bootstrap the app via the .NET generic host (`Host.CreateDefaultBuilder`).  
- Add package references required for hosting, DI abstractions and Terminal.Gui (`Microsoft.Extensions.Hosting`, `Microsoft.Extensions.DependencyInjection.Abstractions`, `Terminal.Gui`).

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960583a2800832ebf979ead1dc12a4c)